### PR TITLE
fix: correct img_url size hash typo and restore Page content styling

### DIFF
--- a/custom-es.hbs
+++ b/custom-es.hbs
@@ -19,7 +19,7 @@
     <div class="flex items-center text-sm text-gray-400">
       {{#foreach authors}}
       {{#if profile_image}}
-      <img class="h-6 w-6 rounded-full mr-2 object-cover" src="{{img_url profile_image size=" xs"}}" alt="{{name}}">
+      <img class="h-6 w-6 rounded-full mr-2 object-cover" src="{{img_url profile_image size="xs"}}" alt="{{name}}">
       {{else}}
       <span
         class="h-6 w-6 bg-gray-800 rounded-full flex items-center justify-center text-[10px] text-gray-300 font-bold mr-2">{{name}}</span>

--- a/page.hbs
+++ b/page.hbs
@@ -2,7 +2,7 @@
 
 {{#page}}
     <h1 class="text-4xl text-white font-bold mb-4">{{title}}</h1>
-    <article class="prose prose-invert prose-lg max-w-none text-gray-300 leading-relaxed">
+    <article class="gh-content max-w-none">
         {{{content}}}
     </article>
 {{/page}}

--- a/partials/feature-image.hbs
+++ b/partials/feature-image.hbs
@@ -1,6 +1,6 @@
 {{#if feature_image}}
 <figure class="feature-image-wrapper">
-    <img src="{{img_url feature_image size=" xl"}}"
+    <img src="{{img_url feature_image size="xl"}}"
         alt="{{#if feature_image_alt}}{{feature_image_alt}}{{else}}{{title}}{{/if}}"
         class="w-full h-auto object-cover rounded-xl border border-gray-800 shadow-2xl">
 </figure>

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -2,7 +2,7 @@
   class="bg-dark-card border border-gray-700 rounded-xl overflow-hidden hover:border-gray-500 transition-colors group flex flex-col h-full">
   {{#if feature_image}}
   <a href="{{url}}" class="block aspect-[16/9] overflow-hidden">
-    <img src="{{img_url feature_image size=" m"}}"
+    <img src="{{img_url feature_image size="m"}}"
       alt="{{#if feature_image_alt}}{{feature_image_alt}}{{else}}{{title}}{{/if}}"
       class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300">
   </a>


### PR DESCRIPTION
# v2 To Do:

- Improvements into Homepage content blocks/sections []
- Update and migrate templates to the new design:
  - `page.hbs` []
  - `page-recommendations.hbs` []
  - `page-tags.hbs` []
  - `tag.hbs` []
  - `custom-notocbot.hbs` []
  - `author.hbs` []