### PR TITLE
fix: update Spanish translations and improve date format in templates

### DIFF
--- a/custom-es.hbs
+++ b/custom-es.hbs
@@ -8,8 +8,8 @@
       <span
         class="bg-brand-red text-white text-[10px] font-bold px-3 py-1 rounded-full tracking-wide uppercase font-mono">{{primary_tag.name}}</span>
       {{/if}}
-      <span class="text-gray-500 text-xs"><i class="far fa-clock mr-1"></i> {{reading_time minute=(t "Just a minute or
-        less") minutes=(t "Takes about % minutes to read")}}</span>
+      <span class="text-gray-500 text-xs"><i class="far fa-clock mr-1"></i> {{reading_time minute="Menos de un minuto"
+        minutes="Alrededor de % minutos para leer"}}</span>
     </div>
 
     <h1 class="text-3xl md:text-5xl font-bold leading-tight tracking-tight text-white mb-3">{{title}}</h1>
@@ -27,7 +27,7 @@
       {{/foreach}}
       <span class="mr-2 text-gray-300 font-medium">{{authors}}</span>
       <span class="mr-2 text-gray-600">|</span>
-      <span>{{date published_at format="d MMMM YYYY"}}</span>
+      <span>{{date published_at format="DD/MM/YYYY"}}</span>
     </div>
   </div>
 
@@ -66,11 +66,11 @@
 
   {{#is "post"}}
   <div class="mt-16 border-t border-gray-800 pt-8">
-    <h2 class="text-2xl font-bold text-white mb-6">Related content</h2>
-    {{#get "posts" include="authors" filter="id:-{{id}}+tags:[{{primary_tag.slug}}]" limit="2" as |next|}}
+    <h2 class="text-2xl font-bold text-white mb-6">Contenido relacionado</h2>
+    {{#get "posts" include="authors" filter="id:-{{id}}+tags:[es,{{primary_tag.slug}}]" limit="2" as |next|}}
     {{#if next}}
     <section class="grid grid-cols-1 md:grid-cols-2 gap-6">
-      {{#foreach next}}{{> "post-card"}}{{/foreach}}
+      {{#foreach next}}{{> "post-card-es"}}{{/foreach}}
     </section>
     {{/if}}
     {{/get}}
@@ -79,13 +79,13 @@
   <section id="comments" class="mt-8 border-t border-gray-800 pt-8">
     {{#if comments}}
     <div class="gh-comments">
-      {{#if @member}}{{comments count=false mode=dark title="Opinions?"}}
+      {{#if @member}}{{comments count=false mode=dark title="Opiniones?"}}
       {{else}}{{> "social-sso"}}{{comments count=false mode=dark title=" "}}
       {{/if}}
     </div>
     {{/if}}
   </section>
 
-  {{> "components/author-box"}}
+  {{> "components/author-box-es"}}
   {{/is}}
   {{/post}}

--- a/partials/post-card-es.hbs
+++ b/partials/post-card-es.hbs
@@ -1,24 +1,23 @@
-<article id="{{slug}}">
-  <a href="{{url absolute=" true"}}" alt="{{title}}">
-    {{> "feature-image"}}
+<article
+  class="bg-dark-card border border-gray-700 rounded-xl overflow-hidden hover:border-gray-500 transition-colors group flex flex-col h-full">
+  {{#if feature_image}}
+  <a href="{{url}}" class="block aspect-[16/9] overflow-hidden">
+    <img src="{{img_url feature_image size="m"}}"
+      alt="{{#if feature_image_alt}}{{feature_image_alt}}{{else}}{{title}}{{/if}}"
+      class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300">
   </a>
-  <div>
-
-    <h1>
-      <a href="{{url absolute=" true"}}">
-        {{title}}
-      </a>
-    </h1>
-
-    <p class="mt-2 text-sm line-clamp-3 text-light">
-      {{excerpt}}
-    </p>
-
-    <a href="{{url absolute=" true"}}" class="inline-flex items-center gap-1 mt-4 text-sm font-medium group"
-      alt="{{title}}" rel="bookmark">
-      <h4 class="block transition-all group-hover:ms-0.5" alt="{{title}}">
-                        Leer más &rarr;
-      </h4>
-    </a>
+  {{/if}}
+  <div class="p-5 flex flex-col flex-grow">
+    {{#if primary_tag}}
+    <a href="{{primary_tag.url}}"
+      class="text-xs font-bold text-brand-purple uppercase tracking-wider mb-2 hover:underline font-mono">{{primary_tag.name}}</a>
+    {{/if}}
+    <h3 class="text-lg font-semibold text-white group-hover:text-brand-purple transition-colors leading-tight mb-2"><a
+        href="{{url}}">{{title}}</a></h3>
+    <p class="text-sm text-gray-400 flex-grow line-clamp-2">{{excerpt words="20"}}</p>
+    <div class="flex items-center justify-between text-xs text-gray-500 mt-4 pt-3 border-t border-gray-800">
+      <span>{{date published_at format="DD/MM/YYYY"}}</span>
+      <span>{{reading_time minute="Menos de un minuto" minutes="Alrededor de % minutos de lectura"}}</span>
+    </div>
   </div>
 </article>


### PR DESCRIPTION
# v2 To Do:

- Improvements into Homepage content blocks/sections []
- Update and migrate templates to the new design:
  - `page.hbs` []
  - `page-recommendations.hbs` []
  - `page-tags.hbs` []
  - `tag.hbs` []
  - `custom-notocbot.hbs` []
  - `author.hbs` []