### PR TITLE
fix(nav): make secondary navigation accessible and responsive

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -33,5 +33,6 @@
   "View all": "View all",
   "Related content": "Related content",
   "Just a minute or less": "Just a minute or less",
-  "Takes about % minutes to read": "Takes about % minutes to read"
+  "Takes about % minutes to read": "Takes about % minutes to read",
+  "Secondary navigation": "Secondary navigation"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -39,5 +39,6 @@
   "Author": "Autor",
   "Table of Contents": "Índice de contenidos",
   "Just a minute or less": "Menos de un minuto",
-  "Takes about % minutes to read": "Alrededor de % minutos para leer"
+  "Takes about % minutes to read": "Alrededor de % minutos para leer",
+  "Secondary navigation": "Navegación secundaria"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -29,5 +29,6 @@
   "1 min read": "1 min de leitura",
   "% min read": "% min de leitura",
   "< 1 min read": "< 1 min de leitura",
-  "Search": "Pesquise SREDevOps.org"
+  "Search": "Pesquise SREDevOps.org",
+  "Secondary navigation": "Navegação secundária"
 }

--- a/partials/footer.hbs
+++ b/partials/footer.hbs
@@ -2,12 +2,8 @@
 
   {{!-- Secondary Navigation (Footer Links) --}}
   {{#if @site.secondary_navigation}}
-  <div
-    class="flex flex-col items-center gap-y-3 text-xs mb-6 font-medium text-gray-400 sm:flex-row sm:flex-wrap sm:justify-center sm:gap-x-6 sm:gap-y-2 sm:text-sm">
+  <div class="mb-6 text-xs font-medium sm:text-sm">
     {{navigation type="secondary"}}
-  </div>
-  {{else}}
-  <div>
   </div>
   {{/if}}
 

--- a/partials/navigation.hbs
+++ b/partials/navigation.hbs
@@ -1,11 +1,13 @@
 {{#if isSecondary}}
-    <ul class="flex flex-wrap justify-center gap-2" role="menu">
-        {{#foreach navigation}}
-            <li class="flex items-center gap-2 px-4 py-2" role="menuitem">
-                <a href="{{url absolute="true"}}">{{label}}</a>
-            </li>
-        {{/foreach}}
-    </ul>
+    <nav aria-label="{{t "Secondary navigation"}}">
+        <ul class="flex flex-wrap items-center justify-center divide-x divide-gray-800" role="menu">
+            {{#foreach navigation}}
+                <li class="flex items-center px-4 first:pl-0 last:pr-0" role="menuitem">
+                    <a href="{{url absolute="true"}}" class="rounded-sm text-gray-400 transition-colors hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-purple">{{label}}</a>
+                </li>
+            {{/foreach}}
+        </ul>
+    </nav>
 {{else}}
     <ul class="nav flex flex-col gap-2 w-full md:flex-row md:items-center md:gap-6" role="menu">
         {{#foreach navigation}}


### PR DESCRIPTION
- wrap secondary nav in a <nav aria-label> landmark instead of a bare <ul>
- replace ad-hoc item spacing with divide-x separators to match primary nav
- add hover/focus-visible states so keyboard focus is visible
- simplify footer wrapper now that the nav partial owns its own responsive layout
- add 'Secondary navigation' locale string (en/es/pt)